### PR TITLE
🐛 Fix shebang: Add -S flag for env compatibility

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: "3.13"
   commands:
     - pip install uv
-    - uv run --group docs sphinx-build docs $READTHEDOCS_OUTPUT/html -b html -W
+    - uv run --link-mode=copy --group docs sphinx-build docs $READTHEDOCS_OUTPUT/html -b html -W
 
 sphinx:
   configuration: docs/conf.py

--- a/README.md
+++ b/README.md
@@ -38,12 +38,14 @@ autopep723 upgrade script.py
 You can use `autopep723` directly as a shebang:
 
 ```python
-#!/usr/bin/env uvx autopep723
+#!/usr/bin/env -S uvx autopep723
 import requests
 import numpy as np
 
 # Your script here...
 ```
+
+**Note**: The `-S` flag is required for `env` to properly handle arguments with spaces. Without it, you'll get an error like `No such file or directory`.
 
 This allows scripts to be executable without explicitly declaring dependencies. The tool detects imports and runs the script using `uv run` with the required packages installed on-the-fly in an ephemeral environment.
 

--- a/docs/_static/.gitkeep
+++ b/docs/_static/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the _static directory is tracked by Git
+# The _static directory is required by Sphinx for static assets

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -69,7 +69,7 @@ The shebang `#!/usr/bin/env autopep723` automatically:
 
 For `uvx` usage, change the shebang to:
 ```python
-#!/usr/bin/env uvx autopep723
+#!/usr/bin/env -S uvx autopep723
 ```
 
 ## Machine Learning Analysis

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -114,11 +114,13 @@ When you run `uvx autopep723`:
 
 ### Unix/Linux/macOS
 
-The shebang `#!/usr/bin/env uvx autopep723` works by:
+The shebang `#!/usr/bin/env -S uvx autopep723` works by:
 
 1. **Shell interpretation**: Shell reads the shebang line
 2. **Command execution**: Runs `uvx autopep723 script.py`
 3. **File as argument**: The script file becomes the argument
+
+**Note**: The `-S` flag is required for `env` to properly handle arguments with spaces. This flag is available in most modern Unix systems (GNU coreutils 8.30+, macOS 10.15+). For older systems, consider using permanent installation with `uv tool install autopep723` and the simpler shebang `#!/usr/bin/env autopep723`.
 
 ### Windows Compatibility
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ autopep723 script.py
 Make your scripts executable with automatic dependency management:
 
 ```python
-#!/usr/bin/env uvx autopep723
+#!/usr/bin/env -S uvx autopep723
 import requests
 import numpy as np
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -104,7 +104,7 @@ autopep723 --help
 Make scripts executable with automatic dependency management:
 
 ```python
-#!/usr/bin/env uvx autopep723
+#!/usr/bin/env -S uvx autopep723
 import requests
 import pandas as pd
 
@@ -112,6 +112,8 @@ response = requests.get("https://api.example.com/data")
 df = pd.DataFrame(response.json())
 print(df.head())
 ```
+
+**Note**: The `-S` flag is required for `env` to properly handle arguments with spaces. Without it, you'll get an error like `No such file or directory`.
 
 Make the script executable and run it:
 
@@ -149,6 +151,8 @@ Then use:
 ```python
 #!/usr/bin/env autopep723
 ```
+
+This doesn't require the `-S` flag since there are no arguments to pass.
 
 ## Import Name Mapping
 

--- a/magic.py
+++ b/magic.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env -S uvx autopep723
+import pandas as pd
+import requests
+
+response = requests.get("https://jsonplaceholder.typicode.com/users")
+df = pd.DataFrame(response.json())
+print(df.head())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "autopep723"
-version = "0.1.0"
+version = "0.1.1"
 description = "Auto-generate PEP 723 metadata for Python scripts by analyzing imports"
 readme = "README.md"
 authors = [{ name = "Martín Gaitán", email = "gaitan@gmail.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "autopep723"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Problem

The documented shebang `#!/usr/bin/env uvx autopep723` was failing with the error:
```
/usr/bin/env: 'uvx autopep723': No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```

This happens because `env` cannot handle arguments with spaces without the `-S` flag.

## Solution

- ✅ Fix all shebang examples to use `#!/usr/bin/env -S uvx autopep723`
- ✅ Add explanatory notes about the `-S` flag requirement  
- ✅ Add compatibility information for older systems
- ✅ Include working example script (magic.py) for testing
- ✅ Bump version to 0.1.1

## Testing

Verified that the corrected shebang works properly:
```bash
./magic.py
# Successfully detects dependencies and runs with uv
```

## Compatibility

The `-S` flag is available in:
- GNU coreutils 8.30+
- macOS 10.15+
- Most modern Unix systems

For older systems, users can fall back to permanent installation with `uv tool install autopep723` and use the simpler shebang `#!/usr/bin/env autopep723`.

Fixes a critical bug that prevented the main advertised feature from working.